### PR TITLE
Add amount formatting to TECurrency

### DIFF
--- a/src/main/java/com/erigitic/config/TECurrency.java
+++ b/src/main/java/com/erigitic/config/TECurrency.java
@@ -51,7 +51,7 @@ public class TECurrency implements Currency {
 
     @Override
     public Text format(BigDecimal amount, int numFractionDigits) {
-        return Text.of(amount.setScale(numFractionDigits, BigDecimal.ROUND_HALF_UP));
+        return Text.of(symbol, NumberFormat.getInstance(Locale.ENGLISH).format(amount.setScale(numFractionDigits, BigDecimal.ROUND_HALF_UP)));
     }
 
     @Override


### PR DESCRIPTION
Due to the nature of the Economy Service API, `Currency#format(BigDecimal)` should format the given number into a `Text` object used to display the amount. This means that it should also include the currency symbol (which I have added in this PR).

I've also added a method call that will format the amount using commas. For example, `BigDecimal.valueOf(65536D)` will be formatted as "65,536" and `BigDecimal.valueOf(4392283.37D)` will be formatted as "4,392,283.37". This makes the number easier to read when displayed.

I used the English locale as other languages may display numbers differently. For example, the French locale would format the number `BigDecimal.valueOf(4392283.37D)` as "4.392.283,37". You could go so far as adding a locale option or using the server locale, but that's up to you.