### PR TITLE
[Prop] Issue 142 - Minimum balance

### DIFF
--- a/src/main/java/com/erigitic/commands/AdminPayCommand.java
+++ b/src/main/java/com/erigitic/commands/AdminPayCommand.java
@@ -86,6 +86,9 @@ public class AdminPayCommand implements CommandExecutor {
                     recipient.sendMessage(Text.of(TextColors.GOLD, amountText, TextColors.GRAY, " has been removed from your account by ",
                             TextColors.GOLD, src.getName(), TextColors.GRAY, "."));
                 }
+            } else {
+                //Do not return a success
+                throw new CommandException(Text.of(TextColors.RED, "[TE] Transaction unsuccessful: " + transactionResult.getResult().toString()));
             }
         } else {
             src.sendMessage(Text.of(TextColors.RED, "The amount must be numeric."));

--- a/src/main/java/com/erigitic/config/TETransferResult.java
+++ b/src/main/java/com/erigitic/config/TETransferResult.java
@@ -28,9 +28,7 @@ package com.erigitic.config;
 import org.spongepowered.api.service.context.Context;
 import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.economy.account.Account;
-import org.spongepowered.api.service.economy.transaction.ResultType;
-import org.spongepowered.api.service.economy.transaction.TransactionType;
-import org.spongepowered.api.service.economy.transaction.TransferResult;
+import org.spongepowered.api.service.economy.transaction.*;
 
 import java.math.BigDecimal;
 import java.util.Set;
@@ -44,6 +42,16 @@ public class TETransferResult implements TransferResult {
     private Set<Context> contexts;
     private ResultType resultType;
     private TransactionType transactionType;
+
+    public TETransferResult(TransactionResult transactionResultFrom, TransactionResult transactionResultTo) {
+        this.account = transactionResultFrom.getAccount();
+        this.to = transactionResultTo.getAccount();
+        this.currency = transactionResultFrom.getCurrency();
+        this.amount = transactionResultFrom.getAmount();
+        this.contexts = transactionResultFrom.getContexts();
+        this.resultType = ResultType.SUCCESS;
+        this.transactionType = TransactionTypes.TRANSFER;
+    }
 
     public TETransferResult(Account account, Account to, Currency currency, BigDecimal amount, Set<Context> contexts,
                             ResultType resultType, TransactionType transactionType) {

--- a/src/main/java/com/erigitic/main/TotalEconomy.java
+++ b/src/main/java/com/erigitic/main/TotalEconomy.java
@@ -125,8 +125,12 @@ public class TotalEconomy {
 
         hasMaxMoneyCap = config.getNode("features", "moneycap", "max", "enable").getBoolean() &&
             config.getNode("features", "moneycap", "max", "amount").getInt(0) >= 0;
-        hasMinMoneyCap = config.getNode("features", "moneycap", "min", "enable").getBoolean() &&
-            config.getNode("features", "moneycap", "min", "amount").getInt(0) <= 0;
+
+        //DISABLED after discussion in pull#140 concluded to hard code the value
+        // - Enable this to re-enable a custom minimal cap
+        //hasMinMoneyCap = config.getNode("features", "moneycap", "min", "enable").getBoolean() &&
+        //    config.getNode("features", "moneycap", "min", "amount").getInt(0) <= 0;
+        hasMinMoneyCap = true;
 
         accountManager = new AccountManager(this);
 
@@ -141,7 +145,10 @@ public class TotalEconomy {
             moneyCapMax = new BigDecimal(config.getNode("features", "moneycap", "max", "amount").getString("0"));
         } else moneyCapMax = null;
         if (hasMinMoneyCap) {
-            moneyCapMin = new BigDecimal(config.getNode("features", "moneycap", "min", "amount").getString("0"));
+            //DISABLED after discussion in pull#140 concluded to hard code the value
+            // - Enable this to re-enable a custom minimal cap
+            //moneyCapMin = new BigDecimal(config.getNode("features", "moneycap", "min", "amount").getString("0"));
+            moneyCapMin = new BigDecimal("0");
         } else moneyCapMin = null;
 
         if (databaseActive) {
@@ -223,8 +230,10 @@ public class TotalEconomy {
                 config.getNode("features", "jobs", "notifications").setValue(true);
                 config.getNode("features", "moneycap", "max", "enable").setValue(hasMaxMoneyCap);
                 config.getNode("features", "moneycap", "max", "amount").setValue(10000000);
-                config.getNode("features", "moneycap", "min", "enable").setValue(hasMinMoneyCap);
-                config.getNode("features", "moneycap", "min", "amount").setValue(-10000000);
+                //DISABLED after discussion in pull#140 concluded to hard code the value
+                // - Enable this to re-enable a custom minimal cap
+                //config.getNode("features", "moneycap", "min", "enable").setValue(hasMinMoneyCap);
+                //config.getNode("features", "moneycap", "min", "amount").setValue(-10000000);
                 config.getNode("startbalance").setValue(100);
                 config.getNode("currency-singular").setValue("Dollar");
                 config.getNode("currency-plural").setValue("Dollars");


### PR DESCRIPTION
Hey @Erigitic it's me again 😉 
My proposal for a solution to #142 

Summary:
* Split the money cap feature into ``max`` and ``min`` 
* Instead of handling a ``boolean`` and a ``BigInteger``, just make the cap an ``Optional<BigInteger>``

I've edited the transaction implementations of ``deposit`` and ``withdraw`` to enforce this caps and edited ``transfer`` so it respects the result of the two above when returning it's result.
I've also edited ``AdminPayCommand`` so it raises an exception when the payment wasn't successful.

Regards,

Mark

PS: I recommend to change the base branch again since I still can only select existing branches.

Initial commit message
---
* Rename moneyCap to maximum money cap
* Add a minimum money cap
* Return ACCOUNT_NO_SPACE when any cap has been triggered
* Improvement: Do not actually write on the config until the transaction has not been denied
* Add error message to adminPay and payCommand when the transaction failes

Tested on
---
* SpongeAPI 5.1.0-SNAPSHOT
* SpongeVanilla (latest commit in branch [``stable-5``](https://github.com/SpongePowered/SpongeVanilla/tree/stable-5) (corresponding SV version not available))
* SpongeForge (latest commit in branch [``stable-5``](https://github.com/SpongePowered/SpongeForge/tree/stable-5) (corresponding SV version not available))

[Note: Testing was briefly done, I would like to have s.o. testing this a bit more]

Linked issues
---
* #125 resolved for AdminPayCommand
* #142 