### PR TITLE
Fix FishingEvent$Stop listener throwing IooBException

### DIFF
--- a/src/main/java/com/erigitic/jobs/TEJobManager.java
+++ b/src/main/java/com/erigitic/jobs/TEJobManager.java
@@ -736,6 +736,9 @@ public class TEJobManager {
     @Listener
     public void onPlayerFish(FishingEvent.Stop event) {
         if (event.getCause().first(Player.class).isPresent()) {
+            if (event.getItemStackTransaction().size() == 0) { // no transaction, so execution can stop
+                return;
+            }
             Transaction<ItemStackSnapshot> itemTransaction = event.getItemStackTransaction().get(0);
             ItemStack itemStack = itemTransaction.getFinal().createStack();
             Player player = event.getCause().first(Player.class).get();


### PR DESCRIPTION
This PR resolves an issue where the `FishingEvent$Stop` listener would throw an exception on newer builds of Sponge, due to [a change in behavior](https://github.com/SpongePowered/SpongeCommon/commit/ce0e227) which specifies that the transaction set is not necessarily non-empty.