### PR TITLE
isNumeric Bypass / BigDecimal Conversion DoS Fix

### DIFF
--- a/src/main/java/com/erigitic/main/TotalEconomy.java
+++ b/src/main/java/com/erigitic/main/TotalEconomy.java
@@ -337,7 +337,7 @@ public class TotalEconomy {
         NumberFormat formatter = NumberFormat.getInstance();
         ParsePosition pos = new ParsePosition(0);
         formatter.parse(str, pos);
-        return str.length() == pos.getIndex();
+        return !str.toLowerCase().contains("e") && str.length() == pos.getIndex();
     }
 
     public AccountManager getAccountManager() {


### PR DESCRIPTION
Adds check for E character to isNumeric to prevent a bypass. For example, running the command /pay VALID_ONLINE_USER 1.3E10000000000 is valid according to isNumeric, and is then processed as a BigDouble, causing the server to freeze after a short period of time. Spamming the command causes the server to freeze almost immediately.