### PR TITLE
Forcing save on server stopping

### DIFF
--- a/src/main/java/com/erigitic/config/AccountManager.java
+++ b/src/main/java/com/erigitic/config/AccountManager.java
@@ -556,7 +556,7 @@ public class AccountManager implements EconomyService {
     /**
      * Save the account configuration file
      */
-    private void saveConfiguration() {
+    public void saveConfiguration() {
         try {
             loader.save(accountConfig);
         } catch (IOException e) {

--- a/src/main/java/com/erigitic/main/TotalEconomy.java
+++ b/src/main/java/com/erigitic/main/TotalEconomy.java
@@ -51,6 +51,7 @@ import org.spongepowered.api.data.DataRegistration;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.EventManager;
 import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.Order;
 import org.spongepowered.api.event.game.GameReloadEvent;
 import org.spongepowered.api.event.game.state.*;
 import org.spongepowered.api.event.network.ClientConnectionEvent;
@@ -190,12 +191,12 @@ public class TotalEconomy {
         logger.info("Total Economy Started");
     }
 
-    @Listener
+    @Listener(order = Order.LAST)
     public void onServerStopping(GameStoppingServerEvent event) {
         logger.info("Total Economy Stopping");
 
         if (!databaseEnabled) {
-            accountManager.requestConfigurationSave();
+            accountManager.saveConfiguration();
         }
 
         // Remove PlayerShopInfoData from all online users


### PR DESCRIPTION
As the title says, i've modified totaleconomy to force saving the config when the server's closing.
Before this pr, it just asked the config to save, but only if you were lucky enough to have the autosaver task to run when the server was closing, or you had the "save-interval" value set to 0, otherwise your modifies weren't actually stored.
I've experienced this bug in a plugin where i tried to give back some money to the player when the server was stopping.
Another issue was that the event fired on Order.DEFAULT, which isn't the ideal order if you're implementing an api. Now it uses Order.LAST which i think represents better its importance.