### PR TITLE
Fix keys being registered at the wrong time.

### DIFF
--- a/src/main/java/com/erigitic/main/TotalEconomy.java
+++ b/src/main/java/com/erigitic/main/TotalEconomy.java
@@ -280,6 +280,11 @@ public class TotalEconomy {
                 .manipulatorId("playershopinfo")
                 .dataName("playershopinfo")
                 .buildAndRegister(pluginContainer);
+
+        // Load the ShopKeys class during init to avoid problems with potential
+        // async loading
+        @SuppressWarnings("unused")
+        Object unused = ShopKeys.PLAYER_SHOP_INFO;
     }
 
     /**


### PR DESCRIPTION
This prevents class not found errors with Nucleus.

From a previous issue on another plugin:

> Register your keys during pre-init by calling something from the class so that the static members are constructed at that time. The class is only loaded when someone calls for a key, which turns out to be me off the main thread, constructing the keys then. Because I’m only getting users, my async operation should be safe.

I plan to make some changes to Nucleus to try to mitigate this if I can work out a performant way to do it, but you should be in control of when your keys are registered, because you're running the risk of your keys possibly being registered under the wrong plugin anyway, depending on implementation of the Sponge server (I'm not sure if you are added to the cause stack when your data is constructed).

Fixes #262 