### PR TITLE
Fix baltop not supporting database storage

### DIFF
--- a/src/main/java/com/erigitic/commands/BalanceTopCommand.java
+++ b/src/main/java/com/erigitic/commands/BalanceTopCommand.java
@@ -27,29 +27,47 @@ package com.erigitic.commands;
 
 import com.erigitic.config.AccountManager;
 import com.erigitic.config.TEAccount;
-import com.erigitic.config.TECurrency;
 import com.erigitic.main.TotalEconomy;
+import com.erigitic.sql.SQLManager;
+import com.erigitic.sql.SQLQuery;
 import ninja.leaping.configurate.ConfigurationNode;
-import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
-import org.spongepowered.api.command.source.ConsoleSource;
+import org.spongepowered.api.command.args.GenericArguments;
 import org.spongepowered.api.command.spec.CommandExecutor;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.command.spec.CommandSpec;
+import org.spongepowered.api.entity.living.player.User;
 import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.pagination.PaginationList;
 import org.spongepowered.api.service.pagination.PaginationService;
+import org.spongepowered.api.service.user.UserStorageService;
 import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.format.TextColor;
 import org.spongepowered.api.text.format.TextColors;
 
 import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.*;
 
 public class BalanceTopCommand implements CommandExecutor {
+
+    public static CommandSpec commandSpec(TotalEconomy totalEconomy) {
+        return CommandSpec.builder()
+                          .description(Text.of("Display top balances"))
+                          .permission("totaleconomy.command.balancetop")
+                          .arguments(
+                                GenericArguments.optional(
+                                    GenericArguments.string(Text.of("currency"))
+                                )
+                          )
+                          .executor(new BalanceTopCommand(totalEconomy, totalEconomy.getAccountManager()))
+                          .build();
+    }
+
     private TotalEconomy totalEconomy;
     private AccountManager accountManager;
 
@@ -63,35 +81,68 @@ public class BalanceTopCommand implements CommandExecutor {
 
     @Override
     public CommandResult execute(CommandSource src, CommandContext args) throws CommandException {
-        ConfigurationNode accountNode = accountManager.getAccountConfig();
+        Optional<String> optCurrency = args.<String>getOne("currency");
+        Currency currency = null;
         List<Text> accountBalances = new ArrayList<>();
-        Map<String, BigDecimal> accountBalancesMap = new HashMap<>();
-        Currency defaultCurrency = totalEconomy.getDefaultCurrency();
 
-        accountNode.getChildrenMap().keySet().forEach(accountUUID -> {
-            UUID uuid;
+        if (optCurrency.isPresent())
+            currency = totalEconomy.getTECurrencyRegistryModule().getById("totaleconomy:" + optCurrency.get().toLowerCase()).orElse(null);
 
-            // Check if the account is virtual or not. If virtual, skip the rest of the execution and move on to next account.
+        if (currency == null)
+            currency = totalEconomy.getDefaultCurrency();
+        final Currency fCurrency = currency;
+
+        if (totalEconomy.isDatabaseEnabled()) {
             try {
-                uuid = UUID.fromString(accountUUID.toString());
-            } catch (IllegalArgumentException e) {
-                return;
+                Statement statement = totalEconomy.getSqlManager().dataSource.getConnection().createStatement();
+                String currencyColumn = currency.getName() + "_balance";
+                statement.execute("SELECT * FROM accounts ORDER BY `" + currencyColumn + "` DESC LIMIT 10");
+                ResultSet set = statement.getResultSet();
+
+                while (set.next()) {
+                    BigDecimal amount = set.getBigDecimal(currencyColumn);
+                    UUID uuid = UUID.fromString(set.getString("uid"));
+                    Optional<User> optUser = Sponge.getServiceManager().provideUnchecked(UserStorageService.class).get(uuid);
+                    String username = optUser.map(User::getName).orElse("unknown");
+
+                    accountBalances.add(Text.of(TextColors.GRAY, username, ": ", TextColors.GOLD, currency.format(amount)));
+                }
+
+            } catch (SQLException e) {
+                throw new CommandException(Text.of("Failed to query db for ranking!"), e);
             }
 
-            TEAccount playerAccount = (TEAccount) accountManager.getOrCreateAccount(uuid).get();
-            Text playerName = playerAccount.getDisplayName();
+        } else {
 
-            accountBalancesMap.put(playerName.toPlain(), playerAccount.getBalance(defaultCurrency));
-        });
+            ConfigurationNode accountNode = accountManager.getAccountConfig();
+            Map<String, BigDecimal> accountBalancesMap = new HashMap<>();
 
-        accountBalancesMap.entrySet().stream()
-                .sorted(Map.Entry.<String, BigDecimal>comparingByValue().reversed())
-                .limit(10)
-                .forEach(entry -> accountBalances.add(Text.of(TextColors.GRAY, entry.getKey(), ": ", TextColors.GOLD, defaultCurrency.format(entry.getValue()).toPlain())));
+            accountNode.getChildrenMap().keySet().forEach(accountUUID -> {
+                UUID uuid;
+
+                // Check if the account is virtual or not. If virtual, skip the rest of the execution and move on to next account.
+                try {
+                    uuid = UUID.fromString(accountUUID.toString());
+                } catch (IllegalArgumentException e) {
+                    return;
+                }
+
+                TEAccount playerAccount = (TEAccount) accountManager.getOrCreateAccount(uuid).get();
+                Text playerName = playerAccount.getDisplayName();
+
+                accountBalancesMap.put(playerName.toPlain(), playerAccount.getBalance(fCurrency));
+            });
+
+            accountBalancesMap.entrySet().stream()
+                              .sorted(Map.Entry.<String, BigDecimal>comparingByValue().reversed())
+                              .limit(10)
+                              .forEach(entry -> accountBalances.add(Text.of(TextColors.GRAY, entry.getKey(), ": ", TextColors.GOLD, fCurrency.format(entry.getValue()).toPlain())));
+
+        }
 
         builder.title(Text.of(TextColors.GOLD, "Top 10 Balances"))
-                .contents(accountBalances)
-                .sendTo(src);
+               .contents(accountBalances)
+               .sendTo(src);
 
         return CommandResult.success();
     }

--- a/src/main/java/com/erigitic/main/TotalEconomy.java
+++ b/src/main/java/com/erigitic/main/TotalEconomy.java
@@ -302,11 +302,7 @@ public class TotalEconomy {
                 .arguments(GenericArguments.optional(GenericArguments.string(Text.of("currencyName"))))
                 .build();
 
-        CommandSpec balanceTopCommand = CommandSpec.builder()
-                .description(Text.of("Display top balances"))
-                .permission("totaleconomy.command.balancetop")
-                .executor(new BalanceTopCommand(this, accountManager))
-                .build();
+        CommandSpec balanceTopCommand = BalanceTopCommand.commandSpec(this);
 
         CommandSpec payCommand = CommandSpec.builder()
                 .description(Text.of("Pay another player"))
@@ -425,6 +421,10 @@ public class TotalEconomy {
 
     public HashSet<Currency> getCurrencies() {
         return currencies;
+    }
+
+    public AccountManager getAccountManager() {
+        return accountManager;
     }
 
     public JobManager getJobManager() {


### PR DESCRIPTION
Hello there,  
This is code to make ``/baltop`` support databases.    
As you may see it uses a database query to generate the list:  
(``SELECT * FROM accounts ORDER BY `<currency>_balance` LIMIT 10``).  
This should be way faster than the flat-file storage with increasing number of stored accounts.  

This code is not meant to be that pretty as it will be overwritten by my SQL refactor proposal.  
(Oh and somehow the diff looks way more complicated than the actual code changes are. So maybe just look at the files before and after)

---
* Fixes #270 
* Fixes #251 
* Also ran ``Optimize imports`` on ``BalanceTopCommand.java``