### PR TITLE
Fix growthTrait/exp confusion in jobSets configuration.

### DIFF
--- a/src/main/java/com/erigitic/jobs/TEAction.java
+++ b/src/main/java/com/erigitic/jobs/TEAction.java
@@ -49,8 +49,8 @@ public class TEAction {
     private TEActionReward reward;
 
     public void loadConfigNode(String action, ConfigurationNode node) {
-        ConfigurationNode idTraitNode = node.getNode("id-trait");
-        ConfigurationNode growthTraitNode = node.getNode("growth-trait");
+        ConfigurationNode idTraitNode = node.getNode("idTrait");
+        ConfigurationNode growthTraitNode = node.getNode("growthTrait");
 
         if (idTraitNode.isVirtual()) {
             this.action = action;

--- a/src/main/resources/assets/totaleconomy/jobsets.conf
+++ b/src/main/resources/assets/totaleconomy/jobsets.conf
@@ -2,220 +2,220 @@ sets {
     crops {
         break {
             "minecraft:beetroots" {
-                exp="15"
+                exp=15
                 growthTrait=age
-                money="3.75"
+                money=3.75
             }
             "minecraft:brown_mushroom" {
-                exp="7"
-                money="1.75"
+                exp=7
+                money=1.75
             }
             "minecraft:cactus" {
-                exp="7"
-                money="1.75"
+                exp=7
+                money=1.75
             }
             "minecraft:carrots" {
-                exp="15"
+                exp=15
                 growthTrait=age
-                money="3.75"
+                money=3.75
             }
             "minecraft:cocoa" {
-                exp="15"
+                exp=15
                 growthTrait=age
-                money="3.75"
+                money=3.75
             }
             "minecraft:nether_wart" {
-                exp="15"
+                exp=15
                 growthTrait=age
-                money="3.75"
+                money=3.75
             }
             "minecraft:potatoes" {
-                exp="15"
+                exp=15
                 growthTrait=age
-                money="3.75"
+                money=3.75
             }
             "minecraft:red_mushroom" {
-                exp="7"
-                money="1.75"
+                exp=7
+                money=1.75
             }
             "minecraft:reeds" {
-                exp="7"
-                money="1.75"
+                exp=7
+                money=1.75
             }
             "minecraft:wheat" {
-                exp="15"
+                exp=15
                 growthTrait=age
-                money="3.75"
+                money=3.75
             }
         }
     }
     fish {
         catch {
             clownfish {
-                exp="120"
-                money="30.00"
+                exp=120
+                money=30.00
             }
             cod {
-                exp="45"
-                money="11.25"
+                exp=45
+                money=11.25
             }
             pufferfish {
-                exp="105"
-                money="26.25"
+                exp=105
+                money=26.25
             }
             salmon {
-                exp="75"
-                money="18.75"
+                exp=75
+                money=18.75
             }
         }
     }
     lumberjackSet {
         break {
             "minecraft:log" {
-                exp="10"
-                money="1.00"
+                exp=10
+                money=1.00
             }
             "minecraft:log2" {
-                exp="10"
-                money="1.00"
+                exp=10
+                money=1.00
             }
         }
         place {
             "minecraft:sapling" {
-                exp="1"
-                money="0.01"
+                exp=1
+                money=0.01
             }
         }
     }
     mobs {
         kill {
             silverfish {
-                exp="8"
-                money="2.00"
+                exp=8
+                money=2.00
             }
             endermite {
-                exp="8"
-                money="2.00"
+                exp=8
+                money=2.00
             }
             ghast {
-                exp="10"
-                money="2.50"
+                exp=10
+                money=2.50
             }
             cave_spider {
-                exp="12"
-                money="3.00"
+                exp=12
+                money=3.00
             }
             vex {
-                exp="14"
-                money="3.50"
+                exp=14
+                money=3.50
             }
             spider {
-                exp="16"
-                money="4.00"
+                exp=16
+                money=4.00
             }
             skeleton {
-                exp="20"
-                money="5.00"
+                exp=20
+                money=5.00
             }
             zombie {
-                exp="20"
-                money="5.00"
+                exp=20
+                money=5.00
             }
             creeper {
-                exp="20"
-                money="5.00"
+                exp=20
+                money=5.00
             }
             blaze {
-                exp="20"
-                money="5.00"
+                exp=20
+                money=5.00
             }
             husk {
-                exp="20"
-                money="5.00"
+                exp=20
+                money=5.00
             }
             zombie_pigman {
-                exp="20"
-                money="5.00"
+                exp=20
+                money=5.00
             }
             stray {
-                exp="20"
-                money="5.00"
+                exp=20
+                money=5.00
             }
             wither_skeleton {
-                exp="20"
-                money="5.00"
+                exp=20
+                money=5.00
             }
             zombie_villager {
-                exp="20"
-                money="5.00"
+                exp=20
+                money=5.00
             }
             evocation_illager {
-                exp="24"
-                money="6.00"
+                exp=24
+                money=6.00
             }
             vindication_illager {
-                exp="24"
-                money="6.00"
+                exp=24
+                money=6.00
             }
             witch {
-                exp="26"
-                money="6.50"
+                exp=26
+                money=6.50
             }
             guardian {
-                exp="30"
-                money="7.50"
+                exp=30
+                money=7.50
             }
             shulker {
-                exp="30"
-                money="7.50"
+                exp=30
+                money=7.50
             }
             enderman {
-                exp="40"
-                money="10.00"
+                exp=40
+                money=10.00
             }
             elder_guardian {
-                exp="80"
-                money="20.00"
+                exp=80
+                money=20.00
             }
         }
     }
     ores {
         break {
             "minecraft:coal_ore" {
-                exp="15"
-                money="3.75"
+                exp=15
+                money=3.75
             }
             "minecraft:diamond_ore" {
-                exp="75"
-                money="18.75"
+                exp=75
+                money=18.75
             }
             "minecraft:emerald_ore" {
-                exp="90"
-                money="22.50"
+                exp=90
+                money=22.50
             }
             "minecraft:gold_ore" {
-                exp="60"
-                money="15.00"
+                exp=60
+                money=15.00
             }
             "minecraft:iron_ore" {
-                exp="30"
-                money="7.50"
+                exp=30
+                money=7.50
             }
             "minecraft:lapis_ore" {
-                exp="45"
-                money="11.25"
+                exp=45
+                money=11.25
             }
             "minecraft:lit_redstone_ore" {
-                exp="60"
-                money="15.00"
+                exp=60
+                money=15.00
             }
             "minecraft:quartz_ore" {
-                exp="15"
-                money="3.75"
+                exp=15
+                money=3.75
             }
             "minecraft:redstone_ore" {
-                exp="60"
-                money="15.00"
+                exp=60
+                money=15.00
             }
         }
     }


### PR DESCRIPTION
~ Change literal 'growth-trait' to the 'growthTrait' which is used in the default config
~ Change literal 'id-trait' to 'idTrait' in order to match the growthTrait casing
~ Update default configuration to use the correct number types as queried in the `TEAction` class

Fixes: #306 
Fixes: #282