### PR TITLE
Fix 0-value rewards being paid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 v1.8.2
 
 + CHANGE: Job signs now take into account job requirements
++ FIX: Fixed an issue where rewards were always 0 exp and money 
 
 v1.8.1
 

--- a/src/main/java/com/erigitic/jobs/TEAction.java
+++ b/src/main/java/com/erigitic/jobs/TEAction.java
@@ -148,11 +148,12 @@ public class TEAction {
         int max = possibleValues.stream().max(Comparator.comparingInt(Integer::intValue)).orElse(0);
         int min = possibleValues.stream().min(Comparator.comparingInt(Integer::intValue)).orElse(0);
         double percent = (double) (traitValue - min) / (double) (max - min);
+        int expReward = (int) (reward.getExpReward() * percent);
+        double moneyReward = reward.getMoneyReward() * percent;
 
-        reward = new TEActionReward();
-        reward.setValues((int) (reward.getExpReward() * percent), reward.getMoneyReward() * percent, reward.getCurrencyId());
-
-        return reward;
+        TEActionReward partialReward = new TEActionReward();
+        partialReward.setValues(expReward, moneyReward, reward.getCurrencyId());
+        return partialReward;
     }
 
     public Optional<TEActionReward> evaluatePlace(Logger logger, BlockState state) {


### PR DESCRIPTION
Fixes an issue where 0-value rewards were paid out for actions.  
This is caused by the ``#generateReward`` method where the local ``reward`` variable hid the field from ``TEAction``. This is now fixed AND clarified by using a different variable name.  
  
---
Fixes: #314 
