### PR TITLE
Fix SQL syntax error when creating virtual accounts. issue #323

### DIFF
--- a/src/main/java/com/erigitic/commands/BalanceTopCommand.java
+++ b/src/main/java/com/erigitic/commands/BalanceTopCommand.java
@@ -145,7 +145,7 @@ public class BalanceTopCommand implements CommandExecutor {
                     .limit(10)
                     .forEach(entry ->
                         accountBalances.add(Text.of(TextColors.GRAY, entry.getKey(), ": ", TextColors.GOLD, fCurrency.format(entry.getValue()).toPlain()))
-                    );
+            );
         }
 
         builder.title(Text.of(TextColors.GOLD, "Top 10 Balances"))

--- a/src/main/java/com/erigitic/config/AccountManager.java
+++ b/src/main/java/com/erigitic/config/AccountManager.java
@@ -373,9 +373,9 @@ public class AccountManager implements EconomyService {
         String identifier = virtualAccount.getIdentifier();
 
         SqlQuery.builder(sqlManager.dataSource).insert("virtual_accounts")
-        		.columns("uid")
-        		.values(identifier)
-        		.build();
+                .columns("uid")
+                .values(identifier)
+                .build();
 
         for (Currency currency : totalEconomy.getCurrencies()) {
             TECurrency teCurrency = (TECurrency) currency;

--- a/src/main/java/com/erigitic/config/AccountManager.java
+++ b/src/main/java/com/erigitic/config/AccountManager.java
@@ -372,12 +372,17 @@ public class AccountManager implements EconomyService {
     private void createAccountInDatabase(TEVirtualAccount virtualAccount) {
         String identifier = virtualAccount.getIdentifier();
 
+        SqlQuery.builder(sqlManager.dataSource).insert("virtual_accounts")
+        		.columns("uid")
+        		.values(identifier)
+        		.build();
+
         for (Currency currency : totalEconomy.getCurrencies()) {
             TECurrency teCurrency = (TECurrency) currency;
 
-            SqlQuery.builder(sqlManager.dataSource).insert("virtual_accounts")
-                    .columns(teCurrency.getName().toLowerCase() + "_balance")
-                    .values(virtualAccount.getDefaultBalance(teCurrency).toString())
+            SqlQuery.builder(sqlManager.dataSource).update("virtual_accounts")
+                    .set(teCurrency.getName().toLowerCase() + "_balance")
+                    .equals(virtualAccount.getDefaultBalance(teCurrency).toString())
                     .where("uid")
                     .equals(identifier)
                     .build();

--- a/src/main/java/com/erigitic/config/AccountManager.java
+++ b/src/main/java/com/erigitic/config/AccountManager.java
@@ -166,6 +166,7 @@ public class AccountManager implements EconomyService {
                 + "lumberjack int(10) unsigned NOT NULL DEFAULT '1',"
                 + "warrior int(10) unsigned NOT NULL DEFAULT '1',"
                 + "fisherman int(10) unsigned NOT NULL DEFAULT '1',"
+                + "farmer int(10) unsigned NOT NULL DEFAULT '1',"
                 + "FOREIGN KEY (uid) REFERENCES accounts(uid) ON DELETE CASCADE"
         );
 
@@ -174,6 +175,7 @@ public class AccountManager implements EconomyService {
                 + "lumberjack int(10) unsigned NOT NULL DEFAULT '0',"
                 + "warrior int(10) unsigned NOT NULL DEFAULT '0',"
                 + "fisherman int(10) unsigned NOT NULL DEFAULT '0',"
+                + "farmer int(10) unsigned NOT NULL DEFAULT '0',"
                 + "FOREIGN KEY (uid) REFERENCES accounts(uid) ON DELETE CASCADE"
         );
     }


### PR DESCRIPTION
There is SQL syntax error when creating a virtual account with uuid (String).

see https://github.com/Erigitic/TotalEconomy/issues/323

````
INSERT IGNORE INTO virtual_accounts (dollar_balance) VALUES ('100') WHERE uid='bc7fc8ed-f75b-45a0-ad9d-103313551c62'
````

It should be:

````
INSERT IGNORE INTO virtual_accounts (uuid) VALUES ('bc7fc8ed-f75b-45a0-ad9d-103313551c62');
UPDATE virtual_accounts SET dollar_balance='100' WHERE uid='bc7fc8ed-f75b-45a0-ad9d-103313551c62'
````