### PR TITLE
[4/X] Update feature/sql-refractor | Migrator concept & legacy migration

### DIFF
--- a/src/main/java/com/erigitic/except/TEMigrationException.java
+++ b/src/main/java/com/erigitic/except/TEMigrationException.java
@@ -1,0 +1,23 @@
+package com.erigitic.except;
+
+public class TEMigrationException extends TERuntimeException {
+
+    public TEMigrationException() {
+    }
+
+    public TEMigrationException(String message) {
+        super(message);
+    }
+
+    public TEMigrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public TEMigrationException(Throwable cause) {
+        super(cause);
+    }
+
+    public TEMigrationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/com/erigitic/jobs/JobManager.java
+++ b/src/main/java/com/erigitic/jobs/JobManager.java
@@ -34,12 +34,7 @@ import com.erigitic.util.MessageManager;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
@@ -500,6 +495,13 @@ public class JobManager {
         }
 
         return getJob("unemployed", false);
+    }
+
+    /**
+     * Returns a map of all available jobs.
+     */
+    public Map<String, TEJob> getJobs() {
+        return Collections.unmodifiableMap(jobsMap);
     }
 
     /**

--- a/src/main/java/com/erigitic/migrate/MigrationManager.java
+++ b/src/main/java/com/erigitic/migrate/MigrationManager.java
@@ -1,7 +1,5 @@
 package com.erigitic.migrate;
 
-import com.erigitic.except.TEMigrationException;
-import com.erigitic.migrate.exec.Migrator;
 import com.erigitic.sql.TESqlManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,59 +8,18 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.LinkedList;
-import java.util.List;
 
 @SuppressWarnings("squid:S2095")
 public class MigrationManager {
 
     private static final int LATEST_SCHEMA_VERSION = 2;
 
-    // Better than Getters for loggers?
-    // Worse?
-    // ID instead of class? Or opposite?
     private static final Logger logger = LoggerFactory.getLogger("totaleconomy");
-
-    private static final List<Migrator> fileMigrators = new LinkedList<>();
-    private static final List<Migrator> dbMigrators = new LinkedList<>();
 
     private final TESqlManager sqlManager;
 
     public MigrationManager(TESqlManager sqlManager) {
         this.sqlManager = sqlManager;
-    }
-
-    public void migrate() {
-        if (!sqlManager.isEnabled()) {
-            fileMigrate();
-        } else {
-            dbMigrate();
-        }
-    }
-
-    private void fileMigrate() {
-        throw new UnsupportedOperationException("Not implemented yet!");
-    }
-
-    private void dbMigrate() {
-        try (Connection migrationConnection = sqlManager.getDataSource().getConnection()) {
-            int currentVersion = detectVersion(migrationConnection);
-
-            if (currentVersion == LATEST_SCHEMA_VERSION) {
-                logger.info("Version fits. Nothing to do.");
-
-            } else if (currentVersion > LATEST_SCHEMA_VERSION) {
-                throw new TEMigrationException("Current schema is ahead of the supported data format! Unable to migrate!");
-            } else {
-                runMigrators(dbMigrators);
-            }
-        } catch (SQLException e) {
-            throw new TEMigrationException("A fatal error occurred trying to run db migrations!", e);
-        }
-    }
-
-    private void runMigrators(List<Migrator> migrators) {
-
     }
 
     private int detectVersion(Connection connection) {

--- a/src/main/java/com/erigitic/migrate/MigrationManager.java
+++ b/src/main/java/com/erigitic/migrate/MigrationManager.java
@@ -1,0 +1,112 @@
+package com.erigitic.migrate;
+
+import com.erigitic.except.TEMigrationException;
+import com.erigitic.migrate.exec.Migrator;
+import com.erigitic.sql.TESqlManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+
+@SuppressWarnings("squid:S2095")
+public class MigrationManager {
+
+    private static final int LATEST_SCHEMA_VERSION = 2;
+
+    // Better than Getters for loggers?
+    // Worse?
+    // ID instead of class? Or opposite?
+    private static final Logger logger = LoggerFactory.getLogger("totaleconomy");
+
+    private static final List<Migrator> fileMigrators = new LinkedList<>();
+    private static final List<Migrator> dbMigrators = new LinkedList<>();
+
+    private final TESqlManager sqlManager;
+
+    public MigrationManager(TESqlManager sqlManager) {
+        this.sqlManager = sqlManager;
+    }
+
+    public void migrate() {
+        if (!sqlManager.isEnabled()) {
+            fileMigrate();
+        } else {
+            dbMigrate();
+        }
+    }
+
+    private void fileMigrate() {
+        throw new UnsupportedOperationException("Not implemented yet!");
+    }
+
+    private void dbMigrate() {
+        try (Connection migrationConnection = sqlManager.getDataSource().getConnection()) {
+            int currentVersion = detectVersion(migrationConnection);
+
+            if (currentVersion == LATEST_SCHEMA_VERSION) {
+                logger.info("Version fits. Nothing to do.");
+
+            } else if (currentVersion > LATEST_SCHEMA_VERSION) {
+                throw new TEMigrationException("Current schema is ahead of the supported data format! Unable to migrate!");
+            } else {
+                runMigrators(dbMigrators);
+            }
+        } catch (SQLException e) {
+            throw new TEMigrationException("A fatal error occurred trying to run db migrations!", e);
+        }
+    }
+
+    private void runMigrators(List<Migrator> migrators) {
+
+    }
+
+    private int detectVersion(Connection connection) {
+        // Check for legacy schema first.
+        if (isLegacyDB(connection)) {
+            return 0;
+        }
+
+        String tableName = sqlManager.getTablePrefix() + "meta";
+        String query = "SELECT value FROM ? WHERE ident = 'schema_version'";
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, tableName);
+            ResultSet resultSet = statement.executeQuery();
+            String value = resultSet.getString(1);
+            return Integer.parseInt(value);
+
+        } catch (SQLException e) {
+            logger.error("Failed to detect schema version! SQL failure.", e);
+            return -1;
+        } catch (NumberFormatException e) {
+            logger.error("Failed to determine schema version! NumberFormat failure.", e);
+            return LATEST_SCHEMA_VERSION;
+        }
+    }
+
+    private boolean isLegacyDB(Connection connection) {
+        String query = "SELECT DISTINCT TABLE_NAME FROM information_schema.COLUMNS WHERE SCHEMA_NAME = ?";
+
+        try (PreparedStatement statement = connection.prepareStatement(query)) {
+            statement.setString(1, sqlManager.getDatabaseName());
+
+            ResultSet resultSet = statement.executeQuery();
+            while (resultSet.next()) {
+                String tableName = resultSet.getString(1);
+                if ("virtual_accounts".equals(tableName)) {
+                    return true;
+                }
+            }
+
+        } catch (SQLException e) {
+            logger.error("Could not determine legacy-status. Assuming 'false'.", e);
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/erigitic/migrate/exec/AbstractDBMigrator.java
+++ b/src/main/java/com/erigitic/migrate/exec/AbstractDBMigrator.java
@@ -1,0 +1,97 @@
+package com.erigitic.migrate.exec;
+
+import com.erigitic.except.TEMigrationException;
+import com.erigitic.migrate.util.TableBuilder;
+import com.erigitic.sql.TESqlManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * Migration layer for database migration.
+ * Basically a utility class.
+ */
+public abstract class AbstractDBMigrator implements Migrator {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractDBMigrator.class);
+
+    private TESqlManager sqlManager;
+    private Connection connection;
+
+    protected PreparedStatement prepare(String query) throws SQLException {
+        return getConnection().prepareStatement(query);
+    }
+
+    protected void foreignKeyChecks(boolean enabled) {
+        try (PreparedStatement foreignKeyChecks = prepare("SET FOREIGN_KEY_CHECKS = ?")) {
+            foreignKeyChecks.setBoolean(1, enabled);
+            foreignKeyChecks.execute();
+        } catch (SQLException e) {
+            throw new TEMigrationException("Failed to change foreign key checks!", e);
+        }
+    }
+
+    protected String getEffectiveTableName(String normalName) {
+        return getSqlManager().getTablePrefix()
+                .map(prefix -> prefix + normalName)
+                .orElse(normalName);
+    }
+
+    protected void renameTable(String from, String to) {
+        logger.warn("Renaming table {} to {}", from, to);
+        //language=MySQL
+        String query = "RENAME TABLE ? TO ?";
+        try (PreparedStatement statement = prepare(query)) {
+            statement.setString(1, from);
+            statement.setString(2, to);
+            statement.execute();
+
+        } catch (SQLException e) {
+            throw new TEMigrationException("Failed to rename table: " + from + " to " + to, e);
+        }
+    }
+
+    protected void createTable(String name, TableBuilder builder) {
+
+    }
+
+    protected void dropTable(String from, boolean force) {
+        logger.warn("Dropping table: {}", from);
+        String query = "DROP TABLE ?";
+        try (PreparedStatement statement = prepare(query)) {
+            if (force) {
+                statement.executeQuery("SET FOREIGN_KEY_CHECKS=0");
+            }
+
+            statement.setString(1, from);
+            statement.execute();
+
+            if (force) {
+                statement.executeQuery("SET FOREIGN_KEY_CHECKS=1");
+            }
+        } catch (SQLException e) {
+            throw new TEMigrationException("Failed to drop table: " + from, e);
+        }
+    }
+
+    public TESqlManager getSqlManager() {
+        return sqlManager;
+    }
+
+    protected Connection getConnection() {
+        return connection;
+    }
+
+    @Override
+    public void setSqlManager(TESqlManager sqlManager) {
+        this.sqlManager = sqlManager;
+    }
+
+    @Override
+    public void setConnection(Connection connection) {
+        this.connection = connection;
+    }
+}

--- a/src/main/java/com/erigitic/migrate/exec/LegacyDBMigrator.java
+++ b/src/main/java/com/erigitic/migrate/exec/LegacyDBMigrator.java
@@ -4,18 +4,17 @@ import com.erigitic.except.TEMigrationException;
 import com.erigitic.migrate.util.ColumnBuilder;
 import com.erigitic.migrate.util.ConstraintBuilder;
 import com.erigitic.migrate.util.TableBuilder;
-import com.sun.javaws.exceptions.InvalidArgumentException;
+import org.intellij.lang.annotations.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.spongepowered.api.service.economy.Currency;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.UUID;
-import java.util.function.Consumer;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Migrates from the legacy database format.
@@ -24,6 +23,7 @@ import java.util.function.Consumer;
 public class LegacyDBMigrator extends AbstractDBMigrator {
 
     private static final Logger logger = LoggerFactory.getLogger(LegacyDBMigrator.class);
+    private static final Pattern UUID_PATTERN = Pattern.compile("([a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{11})");
 
     private String tempVirtualAccountsTable;
     private String tempAccountsTable;
@@ -35,6 +35,9 @@ public class LegacyDBMigrator extends AbstractDBMigrator {
     private String jobsTableName;
     private String balancesTableName;
     private String jobStatTableName;
+
+    private final List<String> legacyAccounts = new LinkedList<>();
+    private final Map<String, UUID> legacyVAccounts = new HashMap<>();
 
     @Override
     public int fromVersion() {
@@ -55,6 +58,7 @@ public class LegacyDBMigrator extends AbstractDBMigrator {
     }
 
     private void moveLegacyTables() {
+        logger.info("Moving legacy tables out the way...");
         tempAccountsTable = getEffectiveTableName("accounts_legacy");
         tempVirtualAccountsTable = getEffectiveTableName("vaccounts_legacy");
         tempExperienceTable = getEffectiveTableName("experience_legacy");
@@ -67,6 +71,7 @@ public class LegacyDBMigrator extends AbstractDBMigrator {
     }
 
     private void createTables() {
+        logger.info("Creating new table schema...");
         metaTableName = getEffectiveTableName("meta");
         accountTableName = getEffectiveTableName("accounts");
         currenciesTableName = getEffectiveTableName("currencies");
@@ -126,31 +131,190 @@ public class LegacyDBMigrator extends AbstractDBMigrator {
 
     private void migrateData() {
         foreignKeyChecks(false);
-
         migrateDataAccounts();
-
+        migrateDataCurrencies();
+        migrateDataBalances();
+        migrateDataJobs();
+        migrateDataJobExp();
         foreignKeyChecks(true);
     }
 
     private void migrateDataAccounts() {
-        List<String> accounts = new LinkedList<>();
-        List<String> virtualAccounts = new LinkedList<>();
+        logger.info("Migrating accounts...");
 
         try (PreparedStatement statement = prepare("SELECT uuid FROM ?")) {
             statement.setString(1, tempAccountsTable);
-            collectStrings(statement.executeQuery(), accounts);
+            collectStrings(statement.executeQuery(), legacyAccounts);
         } catch (SQLException e) {
             throw new TEMigrationException("Failed to read legacy account UUIDs!", e);
         }
 
         try (PreparedStatement statement = prepare("SELECT uid FROM ?")) {
             statement.setString(1, tempVirtualAccountsTable);
-            collectStrings(statement.executeQuery(), virtualAccounts);
+            ResultSet resultSet = statement.executeQuery();
+
+            while (resultSet.next()) {
+                String account = resultSet.getString(1);
+                Matcher matcher = UUID_PATTERN.matcher(account);
+                UUID uuid;
+                if (!matcher.find()) {
+                    uuid = UUID.randomUUID();
+                    logger.warn("Virtual account has no UUID. Generated: \"{}\" for account \"{}\"", uuid, account);
+                } else {
+                    uuid = UUID.fromString(matcher.group(1));
+                }
+                legacyVAccounts.put(account, uuid);
+            }
+
         } catch (SQLException e) {
             throw new TEMigrationException("Failed to read legacy virtual account UUIDs!", e);
         }
 
-        throw new UnsupportedOperationException("");
+        @Language("MySQL")
+        String query = "INSERT INTO ? (uuid, display_name) VALUES (?, ?)";
+        try (PreparedStatement statement = prepare(query)) {
+            statement.setString(1, accountTableName);
+            for (String account : legacyAccounts) {
+                statement.setString(2, account);
+                statement.setString(3, null);
+                statement.executeUpdate();
+            }
+
+            for (Map.Entry<String, UUID> entry : legacyVAccounts.entrySet()) {
+                String account = entry.getKey();
+                UUID uuid = entry.getValue();
+                statement.setString(1, uuid.toString());
+                statement.setString(2, account);
+                statement.executeUpdate();
+            }
+        } catch (SQLException e) {
+            throw new TEMigrationException("Failed to migrate account data!");
+        }
+    }
+
+    private void migrateDataCurrencies() {
+        logger.debug("Inserting currencies for FK constraints...");
+        @Language("MySQL")
+        String query = "INSERT INTO " + currenciesTableName + " (ident) VALUES (?)";
+        try (PreparedStatement statement = prepare(query)) {
+            getPlugin().getCurrencies().forEach(currency -> {
+                try {
+                    statement.setString(1, currency.getId());
+                    statement.executeUpdate();
+                } catch (SQLException e) {
+                    throw new TEMigrationException("Failed to insert currency: " + currency.getId(), e);
+                }
+            });
+        } catch (SQLException e) {
+            throw new TEMigrationException("Failed to prepare insert-query", e);
+        }
+    }
+
+    private void migrateDataBalances() {
+        getPlugin().getCurrencies().forEach(this::migrateDataCurrencyBalance);
+    }
+
+    private void migrateDataCurrencyBalance(Currency currency) {
+        logger.info("Migrating balances for: {}", currency.getId());
+        String legacyColumnName = currency.getName() + "_balance";
+        @Language("MySQL")
+        String query = "INSERT INTO " + balancesTableName + "(currency_ident, account_uuid, balance) VALUES (?, ?, ?)";
+        try (PreparedStatement statement = prepare(query)) {
+            statement.setString(1, currency.getId());
+
+            for (String account : legacyAccounts) {
+                logger.debug("Migrating account: {}", account);
+                statement.setString(2, account);
+                statement.setInt(3, getLegacyBalance(account, legacyColumnName, false));
+            }
+
+            for (Map.Entry<String, UUID> entry : legacyVAccounts.entrySet()) {
+                String account = entry.getKey();
+                UUID uuid = entry.getValue();
+                logger.debug("Migrating virtual account: {}", account);
+                statement.setString(2, uuid.toString());
+                statement.setInt(3, getLegacyBalance(account, legacyColumnName, true));
+            }
+
+        } catch (SQLException e) {
+            throw new TEMigrationException("Failed to migrate balances!", e);
+        }
+    }
+
+    private void migrateDataJobs() {
+        logger.info("Inserting jobs for FK constraints...");
+        @Language("MySQL")
+        String query = "INSERT INTO ? (ident) VALUES (?)";
+        try (PreparedStatement statement = prepare(query)) {
+            Set<String> jobs = getPlugin().getJobManager().getJobs().keySet();
+            for (String job : jobs) {
+                statement.setString(1, jobsTableName);
+                statement.setString(2, job);
+                statement.executeUpdate();
+            }
+
+        } catch (SQLException e) {
+            throw new TEMigrationException("Failed to migrate jobs!", e);
+        }
+    }
+
+    private void migrateDataJobExp() {
+        logger.info("Migrating job experience...");
+        Set<String> jobs = getPlugin().getJobManager().getJobs().keySet();
+
+        for (String job : jobs) {
+            if (tableHasColumn(tempExperienceTable, job) && tableHasColumn(tempLevelsTable, job)) {
+                for (String account : legacyAccounts) {
+                    migrateDataJobExpForAccountAndJob(account, job);
+                }
+            } else {
+                logger.warn("No legacy experience or levels column for job \"{}\"", job);
+            }
+        }
+    }
+
+    private void migrateDataJobExpForAccountAndJob(String account, String job) {
+        logger.debug("Migrating job \"{}\" for uuid \"{}\"", account, job);
+        int experience = 0;
+        int level = 0;
+
+        @Language("MySQL")
+        String query = "SELECT ? FROM ? WHERE `uid` = ?";
+        try (PreparedStatement statement = prepare(query)) {
+            statement.setString(1, job);
+            statement.setString(2, tempExperienceTable);
+            statement.setString(3, account);
+            ResultSet resultSet = statement.executeQuery();
+
+            if (resultSet.next()) {
+                experience = resultSet.getInt(1);
+            } else {
+                logger.debug("No experience data found for account \"{}\" and job \"{}}\" using 0.", account, job);
+            }
+
+            statement.setString(2, tempLevelsTable);
+            resultSet = statement.executeQuery();
+            if (resultSet.next()) {
+                level = resultSet.getInt(1);
+            } else {
+                logger.debug("No level data found for account \"{}\" and job \"{}}\" using 0.", account, job);
+            }
+        } catch (SQLException e) {
+            logger.warn("Failed to migrate job data for user \"{}\" and job \"{}\"", account, job);
+        }
+
+        query = "INSERT INTO ? (account_uuid, job_ident, experience, level) VALUES (?, ?, ?, ?)";
+        try (PreparedStatement statement = prepare(query)) {
+            statement.setString(1, jobStatTableName);
+            statement.setString(2, account);
+            statement.setString(3, job);
+            statement.setInt(4, experience);
+            statement.setInt(5, level);
+            statement.executeUpdate();
+
+        } catch (SQLException e) {
+            logger.warn("Failed to insert job data for user \"{}\" and job \"{}\"", account, job);
+        }
     }
 
     private void collectStrings(ResultSet set, List<String> collection) throws SQLException {
@@ -159,7 +323,40 @@ public class LegacyDBMigrator extends AbstractDBMigrator {
         }
     }
 
-    private void setMetaInformation() {
+    private int getLegacyBalance(String uuid, String columnName, boolean isVirtualAccount) {
+        String tableName = isVirtualAccount ? tempVirtualAccountsTable : tempAccountsTable;
 
+        if (tableHasColumn(tableName, columnName)) {
+
+            @Language("MySQL")
+            String query = "SELECT " + columnName + " FROM " + tableName + " WHERE `uid` = ?";
+            try (PreparedStatement statement = prepare(query)) {
+                statement.setString(1, uuid);
+                ResultSet resultSet = statement.executeQuery();
+
+                if (resultSet.next()) {
+                    return resultSet.getInt(1);
+                } else {
+                    throw new SQLException("No result for query.");
+                }
+
+            } catch (SQLException e) {
+                logger.warn("Failed to retrieve \"{}\" for \"{}\"!", columnName, uuid);
+            }
+        } else {
+            logger.warn("Currency column not available: {}", columnName);
+        }
+        return 0;
+    }
+
+    private void setMetaInformation() {
+        @Language("MySQL")
+        String query = "INSERT INTO ? (ident, value) VALUES ('schema_version', ?) ON DUPLICATE KEY UPDATE value = VALUES(value)";
+        try (PreparedStatement statement = prepare(query)) {
+            statement.setString(1, metaTableName);
+            statement.setInt(2, toVersion());
+        } catch (SQLException e) {
+            throw new TEMigrationException("Failed to update meta table!", e);
+        }
     }
 }

--- a/src/main/java/com/erigitic/migrate/exec/LegacyDBMigrator.java
+++ b/src/main/java/com/erigitic/migrate/exec/LegacyDBMigrator.java
@@ -1,0 +1,165 @@
+package com.erigitic.migrate.exec;
+
+import com.erigitic.except.TEMigrationException;
+import com.erigitic.migrate.util.ColumnBuilder;
+import com.erigitic.migrate.util.ConstraintBuilder;
+import com.erigitic.migrate.util.TableBuilder;
+import com.sun.javaws.exceptions.InvalidArgumentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Migrates from the legacy database format.
+ * (Pre sql-refactor)
+ */
+public class LegacyDBMigrator extends AbstractDBMigrator {
+
+    private static final Logger logger = LoggerFactory.getLogger(LegacyDBMigrator.class);
+
+    private String tempVirtualAccountsTable;
+    private String tempAccountsTable;
+    private String tempExperienceTable;
+    private String tempLevelsTable;
+    private String metaTableName;
+    private String accountTableName;
+    private String currenciesTableName;
+    private String jobsTableName;
+    private String balancesTableName;
+    private String jobStatTableName;
+
+    @Override
+    public int fromVersion() {
+        return 0;
+    }
+
+    @Override
+    public int toVersion() {
+        return 1;
+    }
+
+    @Override
+    public void run() {
+        moveLegacyTables();
+        createTables();
+        migrateData();
+        setMetaInformation();
+    }
+
+    private void moveLegacyTables() {
+        tempAccountsTable = getEffectiveTableName("accounts_legacy");
+        tempVirtualAccountsTable = getEffectiveTableName("vaccounts_legacy");
+        tempExperienceTable = getEffectiveTableName("experience_legacy");
+        tempLevelsTable = getEffectiveTableName("levels_legacy");
+
+        renameTable("accounts", tempAccountsTable);
+        renameTable("virtual_accounts", tempVirtualAccountsTable);
+        renameTable("experience", tempExperienceTable);
+        renameTable("levels", tempLevelsTable);
+    }
+
+    private void createTables() {
+        metaTableName = getEffectiveTableName("meta");
+        accountTableName = getEffectiveTableName("accounts");
+        currenciesTableName = getEffectiveTableName("currencies");
+        jobsTableName = getEffectiveTableName("jobs");
+        balancesTableName = getEffectiveTableName("balances");
+        jobStatTableName = getEffectiveTableName("job_stats");
+
+        createTable(accountTableName,
+                new TableBuilder()
+                        .column(ColumnBuilder.string("uuid").length(60).notNull())
+                        .column(ColumnBuilder.string("alias").length(120).defaultValue("NULL"))
+                        .constraint(ConstraintBuilder.primary().column("uuid"))
+                        .constraint(ConstraintBuilder.unique().column("alias")));
+
+        createTable(jobsTableName,
+                new TableBuilder()
+                        .column(ColumnBuilder.string("uuid").length(60).notNull())
+                        .constraint(ConstraintBuilder.primary().column("uuid"))
+        );
+
+        createTable(currenciesTableName,
+                new TableBuilder()
+                        .column(ColumnBuilder.string("uuid").length(60).notNull())
+                        .constraint(ConstraintBuilder.primary().column("uuid"))
+        );
+
+        createTable(balancesTableName,
+                new TableBuilder()
+                        .column(ColumnBuilder.string("account").length(60).notNull())
+                        .column(ColumnBuilder.string("currency").length(60).notNull())
+                        .column(ColumnBuilder.integer("balance").notNull().defaultValue("0"))
+                        .constraint(ConstraintBuilder.primary().column("account"))
+                        .constraint(ConstraintBuilder.foreignKey().column("account").references("uuid").on(accountTableName))
+                        .constraint(ConstraintBuilder.foreignKey().column("currency").references("uuid").on(currenciesTableName))
+                        .constraint(ConstraintBuilder.unique().columns("account", "currency"))
+        );
+
+        createTable(jobStatTableName,
+                new TableBuilder()
+                        .column(ColumnBuilder.string("account").length(60).notNull())
+                        .column(ColumnBuilder.string("job").length(60).notNull())
+                        .column(ColumnBuilder.integer("experience").defaultValue("0"))
+                        .column(ColumnBuilder.integer("levels").defaultValue("0"))
+                        .constraint(ConstraintBuilder.primary().column("account"))
+                        .constraint(ConstraintBuilder.unique().columns("account", "job"))
+                        .constraint(ConstraintBuilder.foreignKey().column("account").references("uuid").on(accountTableName))
+                        .constraint(ConstraintBuilder.foreignKey().column("job").references("uuid").on(jobsTableName))
+        );
+
+        createTable(metaTableName,
+                new TableBuilder()
+                        .column(ColumnBuilder.string("ident").length(160).notNull())
+                        .column(ColumnBuilder.string("value").length(510))
+                        .constraint(ConstraintBuilder.primary().column("ident"))
+        );
+    }
+
+    private void migrateData() {
+        foreignKeyChecks(false);
+
+        migrateDataAccounts();
+
+        foreignKeyChecks(true);
+    }
+
+    private void migrateDataAccounts() {
+        List<String> accounts = new LinkedList<>();
+        List<String> virtualAccounts = new LinkedList<>();
+
+        try (PreparedStatement statement = prepare("SELECT uuid FROM ?")) {
+            statement.setString(1, tempAccountsTable);
+            collectStrings(statement.executeQuery(), accounts);
+        } catch (SQLException e) {
+            throw new TEMigrationException("Failed to read legacy account UUIDs!", e);
+        }
+
+        try (PreparedStatement statement = prepare("SELECT uid FROM ?")) {
+            statement.setString(1, tempVirtualAccountsTable);
+            collectStrings(statement.executeQuery(), virtualAccounts);
+        } catch (SQLException e) {
+            throw new TEMigrationException("Failed to read legacy virtual account UUIDs!", e);
+        }
+
+        throw new UnsupportedOperationException("");
+    }
+
+    private void collectStrings(ResultSet set, List<String> collection) throws SQLException {
+        while (set.next()) {
+            collection.add(set.getString(1));
+        }
+    }
+
+    private void setMetaInformation() {
+
+    }
+}

--- a/src/main/java/com/erigitic/migrate/exec/Migrator.java
+++ b/src/main/java/com/erigitic/migrate/exec/Migrator.java
@@ -1,0 +1,26 @@
+package com.erigitic.migrate.exec;
+
+import com.erigitic.sql.TESqlManager;
+
+import java.sql.Connection;
+
+/**
+ * Utility class and base template for migrations.
+ * Implements runnable so we keep asynchronous migration in mind.
+ */
+public interface Migrator extends Runnable {
+
+    /**
+     * What schema version is required for this migration to run.
+     */
+    int fromVersion();
+
+    /**
+     * What schema version will be the result of this migration.
+     */
+    int toVersion();
+
+    void setSqlManager(TESqlManager sqlManager);
+
+    void setConnection(Connection connection);
+}

--- a/src/main/java/com/erigitic/migrate/exec/Migrator.java
+++ b/src/main/java/com/erigitic/migrate/exec/Migrator.java
@@ -1,26 +1,30 @@
 package com.erigitic.migrate.exec;
 
-import com.erigitic.sql.TESqlManager;
-
-import java.sql.Connection;
+import com.erigitic.main.TotalEconomy;
 
 /**
  * Utility class and base template for migrations.
- * Implements runnable so we keep asynchronous migration in mind.
+ * Implements runnable so we keep asynchronous migration in mind for now.
  */
-public interface Migrator extends Runnable {
+public abstract class Migrator implements Runnable {
+
+    private TotalEconomy plugin;
 
     /**
      * What schema version is required for this migration to run.
      */
-    int fromVersion();
+    abstract int fromVersion();
 
     /**
      * What schema version will be the result of this migration.
      */
-    int toVersion();
+    abstract int toVersion();
 
-    void setSqlManager(TESqlManager sqlManager);
+    public void setPlugin(TotalEconomy plugin) {
+        this.plugin = plugin;
+    }
 
-    void setConnection(Connection connection);
+    protected TotalEconomy getPlugin() {
+        return plugin;
+    }
 }

--- a/src/main/java/com/erigitic/migrate/util/ColumnBuilder.java
+++ b/src/main/java/com/erigitic/migrate/util/ColumnBuilder.java
@@ -1,0 +1,104 @@
+package com.erigitic.migrate.util;
+
+public abstract class ColumnBuilder {
+
+    public static IntColumnBuilder integer(String name) {
+        return new IntColumnBuilder(name);
+    }
+
+    public static StringColumnBuilder string(String name) {
+        return new StringColumnBuilder(name);
+    }
+
+    private String name;
+    private boolean isNotNull = false;
+    private String defaultValue = null;
+
+    private ColumnBuilder(String name) {
+        this.name = name;
+    }
+
+    public ColumnBuilder notNull() {
+        isNotNull = true;
+        return this;
+    }
+
+    public ColumnBuilder defaultValue(String defaultExpression) {
+        this.defaultValue = defaultExpression;
+        return this;
+    }
+
+    public String build() {
+        StringBuilder text = new StringBuilder();
+        build(text);
+        return text.toString();
+    }
+
+    protected String getName() {
+        return name;
+    }
+
+    protected void build(StringBuilder builder) {
+        if (isNotNull) {
+            builder.append(" NOT NULL");
+        }
+
+        if (defaultValue != null) {
+            builder.append(" DEFAULT ").append(defaultValue);
+        }
+    }
+
+    public static class StringColumnBuilder extends ColumnBuilder {
+
+        private int length = 60;
+
+        private StringColumnBuilder(String name) {
+            super(name);
+        }
+
+        public StringColumnBuilder length(int length) {
+            this.length = length;
+            return this;
+        }
+
+        @Override
+        protected void build(StringBuilder builder) {
+            builder.append(getName())
+                    .append(" VARCHAR2(").append(length).append(")");
+
+            super.build(builder);
+        }
+    }
+
+    public static class IntColumnBuilder extends ColumnBuilder {
+
+        private int size = 32;
+        private boolean isUnsigned = false;
+
+        private IntColumnBuilder(String name) {
+            super(name);
+        }
+
+        public IntColumnBuilder unsigned() {
+            this.isUnsigned = true;
+            return this;
+        }
+
+        public IntColumnBuilder size(int size) {
+            this.size = size;
+            return this;
+        }
+
+        @Override
+        protected void build(StringBuilder builder) {
+            builder.append(getName())
+                    .append(" INT(").append(size).append(")");
+
+            if (isUnsigned) {
+                builder.append(" UNSIGNED");
+            }
+
+            super.build(builder);
+        }
+    }
+}

--- a/src/main/java/com/erigitic/migrate/util/ConstraintBuilder.java
+++ b/src/main/java/com/erigitic/migrate/util/ConstraintBuilder.java
@@ -1,0 +1,161 @@
+package com.erigitic.migrate.util;
+
+import com.erigitic.except.TERuntimeException;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+
+public abstract class ConstraintBuilder {
+
+    public static PrimaryKeyBuilder primary() {
+        return new PrimaryKeyBuilder();
+    }
+
+    public static ForeignKeyBuilder foreignKey() {
+        return new ForeignKeyBuilder();
+    }
+
+    public static UniqueKeyBuilder unique() {
+        return new UniqueKeyBuilder();
+    }
+
+    public static IndexBuilder index() {
+        return new IndexBuilder();
+    }
+
+    protected String name = null;
+
+    public abstract String build();
+
+    public static class PrimaryKeyBuilder extends ConstraintBuilder {
+
+        private List<String> localColumns = new LinkedList<>();
+
+        public PrimaryKeyBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public PrimaryKeyBuilder column(String columnName) {
+            this.localColumns.add(columnName);
+            return this;
+        }
+
+        @Override
+        public String build() {
+            if (localColumns.isEmpty()) {
+                throw new TERuntimeException("Column name may not be null for a primary key!");
+            }
+
+            if (name == null) {
+                name = "pk_" + localColumns.hashCode();
+            }
+
+            return String.format("PRIMARY KEY %s(%s)", name, String.join(",", localColumns));
+        }
+    }
+
+    public static class ForeignKeyBuilder extends ConstraintBuilder {
+
+        private String localColumn = null;
+        private String foreignTable = null;
+        private String foreignColumn = null;
+
+        public ForeignKeyBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public ForeignKeyBuilder column(String localColumn) {
+            this.localColumn = localColumn;
+            return this;
+        }
+
+        public ForeignKeyBuilder references(String foreignColumn) {
+            this.foreignColumn = foreignColumn;
+            return this;
+        }
+
+        public ForeignKeyBuilder on(String foreignTable) {
+            this.foreignTable = foreignTable;
+            return this;
+        }
+
+        @Override
+        public String build() {
+            Objects.requireNonNull(localColumn, "Local localColumn may not be null for a fk!");
+            Objects.requireNonNull(foreignTable, "Foreign table may not be null for a fk!");
+            Objects.requireNonNull(foreignColumn, "Foreign localColumn may not be null for a fk!");
+
+            if (name == null) {
+                name = "fk_" + localColumn + "_" + foreignColumn;
+            }
+
+            return String.format("FOREIGN KEY %s (%s) REFERENCES %s(%s) ON UPDATE CASCADE ON DELETE CASCADE", name, localColumn, foreignTable, foreignColumn);
+        }
+    }
+
+    public static class UniqueKeyBuilder extends ConstraintBuilder {
+
+        private List<String> localColumns = new LinkedList<>();
+
+        public UniqueKeyBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public UniqueKeyBuilder column(String columnName) {
+            Objects.requireNonNull(columnName, "Column name may not be null for a unique constraint!");
+            localColumns.add(columnName);
+            return this;
+        }
+
+        @Override
+        public String build() {
+            if (localColumns.isEmpty()) {
+                throw new TERuntimeException("Column names for a unique constraint may not be empty!");
+            }
+
+            if (name == null) {
+                name = "unique_" + localColumns.hashCode();
+            }
+
+            return String.format("UNIQUE %s (%s)", name, String.join(",", localColumns));
+        }
+
+        public UniqueKeyBuilder columns(String... columns) {
+            for (String column : columns) {
+                column(column);
+            }
+            return this;
+        }
+    }
+
+    public static class IndexBuilder extends ConstraintBuilder {
+
+        private String localColumn = null;
+
+        public IndexBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public IndexBuilder column(String columnName) {
+            this.localColumn = columnName;
+            return this;
+        }
+
+        @Override
+        public String build() {
+            Objects.requireNonNull(localColumn,"Column name may not be null for an index constraint!");
+
+            if (name == null) {
+                name = "index_" + localColumn;
+            }
+
+            return String.format("INDEX %s (%s)", name, localColumn);
+        }
+    }
+}

--- a/src/main/java/com/erigitic/migrate/util/ConstraintBuilder.java
+++ b/src/main/java/com/erigitic/migrate/util/ConstraintBuilder.java
@@ -2,7 +2,6 @@ package com.erigitic.migrate.util;
 
 import com.erigitic.except.TERuntimeException;
 
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -149,7 +148,7 @@ public abstract class ConstraintBuilder {
 
         @Override
         public String build() {
-            Objects.requireNonNull(localColumn,"Column name may not be null for an index constraint!");
+            Objects.requireNonNull(localColumn, "Column name may not be null for an index constraint!");
 
             if (name == null) {
                 name = "index_" + localColumn;

--- a/src/main/java/com/erigitic/migrate/util/TableBuilder.java
+++ b/src/main/java/com/erigitic/migrate/util/TableBuilder.java
@@ -1,0 +1,38 @@
+package com.erigitic.migrate.util;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class TableBuilder {
+
+    private List<String> columns = new LinkedList<>();
+    private List<String> constraints = new LinkedList<>();
+
+    public TableBuilder column(ColumnBuilder column) {
+        return addColumn(column.build());
+    }
+
+    TableBuilder addColumn(String columnText) {
+        columns.add(columnText);
+        return this;
+    }
+
+    public TableBuilder constraint(ConstraintBuilder builder) {
+        return addConstraint(builder.build());
+    }
+
+    TableBuilder addConstraint(String constraintText) {
+        constraints.add(constraintText);
+        return this;
+    }
+
+    public String build(String name) {
+        LinkedList<String> createStatementElements = new LinkedList<>();
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("CREATE TABLE ").append(name).append("( \n");
+        builder.append(String.join(",\n", createStatementElements));
+        builder.append(");");
+        return builder.toString();
+    }
+}

--- a/src/main/java/com/erigitic/sql/TESqlManager.java
+++ b/src/main/java/com/erigitic/sql/TESqlManager.java
@@ -31,6 +31,8 @@ public class TESqlManager implements AutoCloseable {
     private Connection jobsConnection;
     private Connection commandConnection;
     private String tablePrefix;
+    private String databaseName;
+    private boolean enabled = false;
 
     public TESqlManager(TotalEconomy totalEconomy, Logger logger) {
         this.totalEconomy = totalEconomy;
@@ -78,6 +80,14 @@ public class TESqlManager implements AutoCloseable {
                 tablePrefix = totalEconomy.getDatabasePrefix();
             }
 
+            Matcher dbNameMatcher = JDBC_DB_NAME.matcher(jdbcUrl);
+            if (!dbNameMatcher.find() || dbNameMatcher.groupCount() != 1) {
+                throw new SQLException("JDBC url has no database name!");
+            } else {
+                databaseName = dbNameMatcher.group(1);
+            }
+            enabled = true;
+
         } catch (SQLException|TEConnectionException e) {
             logger.warn("Failed to initialize SQL data-source)!", e);
             close();
@@ -122,8 +132,16 @@ public class TESqlManager implements AutoCloseable {
     }
 
     /**
+     * Retuns the current database name.
+     * DO NOT CACHE!
+     */
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    /**
      * Returns the currently configured table prefix.
-     * DO NOT CACHE
+     * DO NOT CACHE!
      */
     public Optional<String> getTablePrefix() {
         return Optional.ofNullable(tablePrefix);
@@ -159,6 +177,13 @@ public class TESqlManager implements AutoCloseable {
      */
     public Connection getCommandConnection() {
         return commandConnection;
+    }
+
+    /**
+     * Whether or not the sql connection has been initialized and is available.
+     */
+    public boolean isEnabled() {
+        return enabled;
     }
 
     /**

--- a/src/main/resources/assets/totaleconomy/sql_refactor/planned_schema.sql
+++ b/src/main/resources/assets/totaleconomy/sql_refactor/planned_schema.sql
@@ -52,7 +52,7 @@ CREATE TABLE currencies (
 # Its current use is for foreign key consistency.
 # #
 CREATE TABLE jobs (
-  uuid         CHAR(36)    UNIQUE PRIMARY KEY
+  ident         CHAR(36)    UNIQUE PRIMARY KEY
 ) COMMENT 'TotalEconomy jobs table. Currently only for constraints.';
 
 # # Balances table # #
@@ -77,15 +77,15 @@ CREATE TABLE balances (
 CREATE TABLE jobs_experience (
   id           INT(64) UNSIGNED AUTO_INCREMENT NOT NULL PRIMARY KEY,
   account_uuid CHAR(36) NOT NULL,
-  job_uuid     CHAR(36) NOT NULL,
+  job_ident     CHAR(36) NOT NULL,
   experience   INT(32)  DEFAULT 0,
   level        INT(32)  DEFAULT 0,
 
   FOREIGN KEY (account_uuid) REFERENCES accounts(uuid) ON DELETE CASCADE ON UPDATE CASCADE,
-  FOREIGN KEY (job_uuid) REFERENCES jobs(uuid) ON DELETE CASCADE ON UPDATE CASCADE,
-  UNIQUE (account_uuid, job_uuid),
+  FOREIGN KEY (job_ident) REFERENCES jobs(ident) ON DELETE CASCADE ON UPDATE CASCADE,
+  UNIQUE (account_uuid, job_ident),
   INDEX (account_uuid),
-  INDEX (job_uuid)
+  INDEX (job_ident)
 ) COMMENT 'TotalEconomy job experience + levels table';
 
 # # # DEFAULT VALUES # # #


### PR DESCRIPTION
## This pull request includes:
* An unfinished ``MigrationManager`` which already has some methods it is going to need in the future.
* An abstract ``Migrator`` class from which all migrators will inherit.
* An abstract ``DBMigrator`` class from which all db migrators will inherit which provides many utility methods for working with the tables/schema.
* An first try on a ``LegacyDBMigrator`` which will migrate the existing database schema to the new one.

Of course, since this is yet another update of the big thing, this code is not yet runnable.

## The basic idea behind migrators
The ``MigrationManager`` determines which migrations to run based on the current schema version and whether or not the schema has already been initialized. This can be used for both the file and DB storage.  
Migrators then - well - migrate the data to the latest version from whatever version currently is used.

### Notes
* The migration must be stable which is why the ``TEMigrationException`` will serve an important role in future code updates (e.g. triggering rollbacks when things go wrong).  
* The schema has been slightly updated as moving jobs to UUIDs is easier in a seperate update than the migration from ``legacy`` to ``latest``.