### PR TITLE
Upon account creation failure: Add exceptions to the log warning

### DIFF
--- a/src/main/java/com/erigitic/config/AccountManager.java
+++ b/src/main/java/com/erigitic/config/AccountManager.java
@@ -227,7 +227,7 @@ public class AccountManager implements EconomyService {
                 addNewCurrenciesToAccount(playerAccount);
             }
         } catch (IOException e) {
-            logger.warn("An error occurred while creating a new account!");
+            logger.warn("An error occurred while creating a new account!", e);
         }
 
         return Optional.of(playerAccount);
@@ -255,7 +255,7 @@ public class AccountManager implements EconomyService {
                 addNewCurrenciesToAccount(virtualAccount);
             }
         } catch (IOException e) {
-            logger.warn("An error occurred while creating a new virtual account!");
+            logger.warn("An error occurred while creating a new virtual account!", e);
         }
 
         return Optional.of(virtualAccount);


### PR DESCRIPTION
No description necessary.

Required for #329 